### PR TITLE
Scale diagram

### DIFF
--- a/venn.js
+++ b/venn.js
@@ -292,15 +292,36 @@
 
     function centerVennDiagram( diagram, width, height, padding ) {
         var diagramBoundaries;
+        var allowedWidth = width - ( 2 * ( padding || 0 ) );
+        var allowedHeight = height - ( 2 * ( padding || 0 ) );
+        var scale;
         var transformX, transformY;
+        var transform = "";
 
         if ( diagram ) {
             diagramBoundaries = diagram[ 0 ][ 0 ].getBBox();
             if ( diagramBoundaries && width && height ) {
-                padding = padding || 0;
-                transformX = Math.floor( ( width - ( 2 * padding ) - diagramBoundaries.width ) / 2 );
-                transformY = Math.floor( ( height - ( 2 * padding ) - diagramBoundaries.height ) / 2 );
-                diagram.attr( "transform", "translate(" + transformX + ","  + transformY + ")" );
+
+                //  See if we need to scale to fit the width/height
+                if ( diagramBoundaries.width > allowedWidth ) {
+                    scale = allowedWidth / diagramBoundaries.width;
+                }
+                if ( diagramBoundaries.height > allowedHeight ) {
+                    if ( !scale || ( allowedHeight / diagramBoundaries.height ) < scale ) {
+                        scale = allowedHeight / diagramBoundaries.height;
+                    }
+                }
+
+                if ( scale ) {
+                    transform = "scale(" + scale + ")";
+                }
+                else {
+                    scale = 1;
+                }
+
+                transformX = Math.floor( ( allowedWidth - ( diagramBoundaries.width * scale ) ) / 2 );
+                transformY = Math.floor( ( allowedHeight - ( diagramBoundaries.height * scale ) ) / 2 );
+                diagram.attr( "transform", "translate(" + transformX + ","  + transformY + ") " + transform );
             }
         }
     }


### PR DESCRIPTION
Sometimes the generated diagram is larger than the bounds of the SVG. This fix applies a scale to ensure that the generated diagram is within bounds and then applies the centering (center_diagram branch).
