### PR TITLE
Upgrade examples to D3 v3

### DIFF
--- a/examples/dynamic.html
+++ b/examples/dynamic.html
@@ -62,7 +62,7 @@
 <div style="clear: both;"></div>
 
 </body>
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 function getSetIntersections() {

--- a/examples/intersection_tooltip.html
+++ b/examples/intersection_tooltip.html
@@ -30,7 +30,7 @@ body {
 }
 </style>
 
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="./lastfm.jsonp"></script>
 <script>

--- a/examples/mds.html
+++ b/examples/mds.html
@@ -15,7 +15,7 @@ body {
     <div class="mds"></div>
 </body>
 
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="http://www.benfrederickson.com/images/mds.js"></script>
 <script src="http://www.numericjs.com/lib/numeric-1.2.6.min.js"></script>

--- a/examples/medical.html
+++ b/examples/medical.html
@@ -17,7 +17,7 @@ Dataset from <a href="http://www.cs.uic.edu/~wilkinson/Publications/venneuler.pd
 
 </body>
 
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="medical.jsonp"></script>
 <script>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -15,7 +15,7 @@ body {
     <div class="simple_example"></div>
 </body>
 
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 // define sets and set set intersections

--- a/examples/weighted.html
+++ b/examples/weighted.html
@@ -12,7 +12,7 @@ set '2' here.
     <div class="weighted_example"></div>
 </body>
 
-<script src="http://d3js.org/d3.v2.min.js"></script>
+<script src="http://d3js.org/d3.v3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 var sets = [{"label":"0","size":1958},


### PR DESCRIPTION
Confirmed that venn.js works with the latest version of D3 with no modifications.

https://github.com/mbostock/d3/wiki/Upgrading-to-3.0