### PR TITLE
Replaced d3 src location with https-supported CDN.

### DIFF
--- a/examples/dynamic.html
+++ b/examples/dynamic.html
@@ -62,13 +62,13 @@
 <div style="clear: both;"></div>
 
 </body>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 function getSetIntersections() {
     areas = d3.selectAll(".venn_area")[0].map(
-        function (element) { 
-            return { sets: element.id.split(","), 
+        function (element) {
+            return { sets: element.id.split(","),
                      size: parseFloat(element.value)};} );
     return areas;
 }

--- a/examples/interactive.html
+++ b/examples/interactive.html
@@ -12,7 +12,7 @@ body {
 </head>
 
 <body>
-    <script src="http://d3js.org/d3.v3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
     <script src="../venn.js"></script>
     <script src="./medical.jsonp"></script>
 

--- a/examples/intersection_tooltip.html
+++ b/examples/intersection_tooltip.html
@@ -30,7 +30,7 @@ body {
 }
 </style>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="./lastfm.jsonp"></script>
 
@@ -59,7 +59,7 @@ div.selectAll("g")
         // Display a tooltip with the current size
         tooltip.transition().duration(400).style("opacity", .9);
         tooltip.text(d.size + " users");
-        
+
         // highlight the current path
         var selection = d3.select(this).transition("tooltip").duration(400);
         selection.select("path")
@@ -72,7 +72,7 @@ div.selectAll("g")
         tooltip.style("left", (d3.event.pageX) + "px")
                .style("top", (d3.event.pageY - 28) + "px");
     })
-    
+
     .on("mouseout", function(d, i) {
         tooltip.transition().duration(400).style("opacity", 0);
         var selection = d3.select(this).transition("tooltip").duration(400);

--- a/examples/mds.html
+++ b/examples/mds.html
@@ -16,7 +16,7 @@ body {
 </body>
 
 <script src="http://www.numericjs.com/lib/numeric-1.2.6.min.js"></script>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="http://www.benfrederickson.com/images/mds.js"></script>
 <script>

--- a/examples/medical.html
+++ b/examples/medical.html
@@ -17,7 +17,7 @@ Dataset from <a href="http://www.cs.uic.edu/~wilkinson/Publications/venneuler.pd
 
 </body>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script src="medical.jsonp"></script>
 <script>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -15,11 +15,11 @@ body {
     <div id="venn"></div>
 </body>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 // define sets and set set intersections
-var sets = [ {sets: ['A'], size: 12}, 
+var sets = [ {sets: ['A'], size: 12},
              {sets: ['B'], size: 12},
              {sets: ['A','B'], size: 2}];
 

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -12,12 +12,12 @@ body {
 </head>
 
 <body>
-    <script src="http://d3js.org/d3.v3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
     <script src="../venn.js"></script>
     <script src="./medical.jsonp"></script>
 
     <h2>Applying styles to venn diagrams</h2>
-    
+
     Here are some examples of applying different styles to the same venn diagram,
     using a dataset from <a
     href="http://www.cs.uic.edu/~wilkinson/Publications/venneuler.pdf"> this
@@ -44,7 +44,7 @@ body {
                 .style("fill", function(d,i) { return colours[i]})
                 .style("font-size", "24px")
                 .style("font-weight", "100");
-                    
+
         </script>
     </div>
     <div id="inverted">
@@ -54,7 +54,7 @@ body {
                              .height(500);
 
             d3.select("#inverted").datum(sets).call(chart)
-            
+
             d3.selectAll("#inverted .venn-circle path")
                 .style("fill-opacity", .8);
 
@@ -101,7 +101,7 @@ body {
                 .style("font-size", "22px");
 
           var defs = d3.select("#dropshadow svg").append("defs");
-        
+
           // from http://stackoverflow.com/questions/12277776/how-to-add-drop-shadow-to-d3-js-pie-or-donut-chart
           var filter = defs.append("filter")
               .attr("id", "dropshadow")
@@ -122,7 +122,7 @@ body {
               .attr("in", "offsetBlur")
           feMerge.append("feMergeNode")
               .attr("in", "SourceGraphic");
-            
+
           areas.attr("filter", "url(#dropshadow)");
         </script>
     </div>

--- a/examples/venn_venn.html
+++ b/examples/venn_venn.html
@@ -15,13 +15,13 @@ font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     <div id="venn"></div>
 </body>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 var sets = [
-            {sets:["Information"], size: 12}, 
+            {sets:["Information"], size: 12},
             {sets:["Things That Overlap"], size: 12},
-            {sets:["Circles"], size: 12},       
+            {sets:["Circles"], size: 12},
             {sets: ["Information", "Things That Overlap"], size: 4, label: "Redundancy"},
             {sets: ["Information", "Circles"], size: 4, label: "Pie Charts", },
             {sets: ["Things That Overlap", "Circles"], size: 4, label: "Eclipses"},

--- a/examples/weighted.html
+++ b/examples/weighted.html
@@ -7,12 +7,12 @@
 
 <body>
     <p> An example providing weights on the importance of each intersection area. This
-defines the non-overlapping intersection areas as being unimportant - so that the sets cluster around 
+defines the non-overlapping intersection areas as being unimportant - so that the sets cluster around
 set '2' here.
     <div id="weighted_example"></div>
 </body>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 <script src="../venn.js"></script>
 <script>
 var sets = [{sets: [0], size: 1958},


### PR DESCRIPTION
Thanks so much for this library! I use a Chrome extension called HTTPS Everywhere (https://www.eff.org/https-everywhere) that automatically uses https when it is available. So that caused me to notice that the examples you linked to in the README won't work on Chrome when https is used because Chrome refuses to load d3.min.js because its URL is http. Here's an example: https://benfred.github.io/venn.js/examples/simple.html

Since the d3 website doesn't support https, I swapped these links with a CDN that does support https. If you accept this pull request, don't forget to merge master into the gh-pages branch so the changes will propagate to the links in the README.