### PR TITLE
Add callback method when diagram has updated

### DIFF
--- a/venn.js
+++ b/venn.js
@@ -1336,16 +1336,9 @@
             // remove old
             var exit = nodes.exit().transition('venn').duration(duration).remove();
 
-            function endall(tween, callback) {
-                var n = 0;
-                tween
-                .each(function() { ++n;})
-                .each("end", function() {if (!--n) callback.apply(this, arguments);});
-            }
-
             exit.select("path")
                 .attrTween("d", pathTween)
-                .call(function () {
+                .call(function (tween) {
                     var n = 0;
                     tween
                     .each(function() { ++n;})

--- a/venn.js
+++ b/venn.js
@@ -1335,8 +1335,25 @@
 
             // remove old
             var exit = nodes.exit().transition('venn').duration(duration).remove();
+
+            function endall(tween, callback) {
+                var n = 0;
+                tween
+                .each(function() { ++n;})
+                .each("end", function() {if (!--n) callback.apply(this, arguments);});
+            }
+
             exit.select("path")
-                .attrTween("d", pathTween);
+                .attrTween("d", pathTween)
+                .call(function () {
+                    var n = 0;
+                    tween
+                    .each(function() { ++n;})
+                    .each("end", function() {if (!--n) {
+                            onDiagramUpdated.apply(this, arguments);
+                        }
+                    });
+                });
 
             var exitText = exit.select("text")
                 .text(function (d) { return label(d); } )
@@ -1438,6 +1455,12 @@
         chart.orientationOrder = function(_) {
             if (!arguments.length) return orientationOrder;
             orientationOrder = _;
+            return chart;
+        };
+
+        chart.onDiagramUpdated = function(_) {
+            if (!arguments.length) return onDiagramUpdated;
+            onDiagramUpdated = _;
             return chart;
         };
 

--- a/venn.js
+++ b/venn.js
@@ -1226,6 +1226,7 @@
             wrap = true,
             styled = true,
             fontSize = null,
+            onDiagramUpdated = function () {return;},
             orientationOrder = null,
             colours = d3.scale.category10(),
             layoutFunction = venn;


### PR DESCRIPTION
Thought other people may think this is useful essentially added a method that will fire when all venn tweens have completed when the diagram is updated. This is helpful if you need logic to fire when the whole diagram is rendered. Used @mbostock 's code from this [thread] (https://groups.google.com/d/msg/d3-js/WC_7Xi6VV50/j1HK0vIWI-EJ) to ensure callback only fires on the last updated items tween