### PR TITLE
Don't include tests and examples in npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+build

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "description": "Area Proportional Venn and Euler Diagrams",
   "main": "build/venn.js",
   "jsnext:main": "index",
+  "files": [
+    "build",
+    "src",
+    "*.js"
+  ],
   "directories": {
     "example": "examples",
     "test": "tests"


### PR DESCRIPTION
With this change `examples` and `tests` directories will not be included when installed as a dependency.  Alternatively, you can use `.npmignore`.  You can check what is being included in an npm package by running `npm pack`.