### PR TITLE
Slightly faster circular segment area calculation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 export {intersectionArea, circleCircleIntersection, circleOverlap, circleArea,
-        distance, circleIntegral} from "./src/circleintersection";
+        distance} from "./src/circleintersection";
 export {venn, greedyLayout, scaleSolution, normalizeSolution, bestInitialLayout,
         lossFunction, disjointCluster, distanceFromIntersectArea} from "./src/layout";
 export {VennDiagram, wrapText, computeTextCentres, computeTextCentre, sortAreas,

--- a/src/circleintersection.js
+++ b/src/circleintersection.js
@@ -148,14 +148,9 @@ function getIntersectionPoints(circles) {
     return ret;
 }
 
-export function circleIntegral(r, x) {
-    var y = Math.sqrt(r * r - x * x);
-    return x * y + r * r * Math.atan2(x, y);
-}
-
-/** Returns the area of a circle of radius r - up to width */
+/** Circular segment area calculation. See http://mathworld.wolfram.com/CircularSegment.html */
 export function circleArea(r, width) {
-    return circleIntegral(r, width - r) - circleIntegral(r, -r);
+    return r * r * Math.acos(1 - width/r) - (r - width) * Math.sqrt(width * (2 * r - width));
 }
 
 /** euclidean distance between two points */

--- a/tests/unittest.js
+++ b/tests/unittest.js
@@ -62,14 +62,6 @@ tape("greedyLayout", function(test) {
     test.end();
 });
 
-tape("circleIntegral", function(test) {
-    nearlyEqual(test, venn.circleIntegral(10, 0), 0, SMALL,
-        "empty circle test");
-    nearlyEqual(test, venn.circleIntegral(10, 10),  Math.PI * 10 * 10 / 2,
-        SMALL, "half circle test");
-    test.end();
-});
-
 tape("circleArea", function(test) {
     nearlyEqual(test, venn.circleArea(10,0), 0, SMALL, "empty circle test");
     nearlyEqual(test, venn.circleArea(10, 10), Math.PI*10*10/2, SMALL,

--- a/venn.js
+++ b/venn.js
@@ -154,14 +154,9 @@
         return ret;
     }
 
-    function circleIntegral(r, x) {
-        var y = Math.sqrt(r * r - x * x);
-        return x * y + r * r * Math.atan2(x, y);
-    }
-
-    /** Returns the area of a circle of radius r - up to width */
+    /** Circular segment area calculation. See http://mathworld.wolfram.com/CircularSegment.html */
     function circleArea(r, width) {
-        return circleIntegral(r, width - r) - circleIntegral(r, -r);
+        return r * r * Math.acos(1 - width/r) - (r - width) * Math.sqrt(width * (2 * r - width));
     }
 
     /** euclidean distance between two points */
@@ -1785,7 +1780,6 @@
     exports.circleOverlap = circleOverlap;
     exports.circleArea = circleArea;
     exports.distance = distance;
-    exports.circleIntegral = circleIntegral;
     exports.venn = venn;
     exports.greedyLayout = greedyLayout;
     exports.scaleSolution = scaleSolution;


### PR DESCRIPTION
Hey @benfred, just wanted to say thanks for developing this awesome library! I found the accompanying blog posts particularly interesting and helpful. There's not much of a difference but it looks like the basic circular segment area formula outlined [here on Wolfram](http://mathworld.wolfram.com/CircularSegment.html) is slightly faster than the circle integral calculation.

