### PR TITLE
Made it possible to specify the loss function.

### DIFF
--- a/src/circleintersection.js
+++ b/src/circleintersection.js
@@ -60,6 +60,12 @@ export function intersectionArea(circles, stats) {
                             y : circle.y + circle.radius * Math.cos(a)
                         });
 
+                    // clamp the width to the largest is can actually be
+                    // (sometimes slightly overflows because of FP errors)
+                    if (width > circle.radius * 2) {
+                        width = circle.radius * 2;
+                    }
+
                     // pick the circle whose arc has the smallest width
                     if ((arc === null) || (arc.width > width)) {
                         arc = { circle : circle,

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -39,11 +39,13 @@ export function VennDiagram() {
             }
             return ret;
         },
-        layoutFunction = venn;
+        layoutFunction = venn,
+        lossFunction = loss;
+
 
     function chart(selection) {
         var data = selection.datum();
-        var solution = layoutFunction(data);
+        var solution = layoutFunction(data, {lossFuncton: lossFunction});
         if (normalize) {
             solution = normalizeSolution(solution,
                                          orientation,
@@ -273,6 +275,12 @@ export function VennDiagram() {
         if (!arguments.length) return orientationOrder;
         orientationOrder = _;
         return chart;
+    };
+
+    chart.lossFunction = function(_) {
+      if (!arguments.length) return lossFunction;
+      lossFunction = _;
+      return chart;
     };
 
     return chart;

--- a/tests/unittest.js
+++ b/tests/unittest.js
@@ -200,6 +200,12 @@ tape("randomFailures", function(test) {
 
     area = venn.intersectionArea(circles);
     nearlyEqual(test, area, 10.963620);
+    circles = [{"x":-0.0014183481763938425,"y":0.0006071174738860746,"radius":510.3115834996166},
+               {"x":875.0163281608848,"y":0.0007003612396158774,"radius":465.1793581792228},
+               {"x":462.7394999567192,"y":387.9359963330729,"radius":172.62633992134658}];
+    area = venn.intersectionArea(circles);
+    test.ok(!Number.isNaN(area), "intersectionArea does not return NaN for valid intersections");
+
     test.end();
 });
 


### PR DESCRIPTION
As described in #81, sometimes an overlap area will not be rendered on the screen.  This can be fixed by updating the initial layout and the loss function (to prioritize ensuring all overlaps are shown).  However, this may not be needed in every case, so a change to the default code is not needed.  The initial layout can be replaced, but not the loss function.  This PR adds the ability to specify the loss function externally.