### PR TITLE
Fix for naming issue with loss function update

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -40,12 +40,12 @@ export function VennDiagram() {
             return ret;
         },
         layoutFunction = venn,
-        lossFunction = loss;
+        loss = lossFunction;
 
 
     function chart(selection) {
         var data = selection.datum();
-        var solution = layoutFunction(data, {lossFuncton: lossFunction});
+        var solution = layoutFunction(data, {lossFuncton: loss});
         if (normalize) {
             solution = normalizeSolution(solution,
                                          orientation,
@@ -278,8 +278,8 @@ export function VennDiagram() {
     };
 
     chart.lossFunction = function(_) {
-      if (!arguments.length) return lossFunction;
-      lossFunction = _;
+      if (!arguments.length) return loss;
+      loss = _;
       return chart;
     };
 


### PR DESCRIPTION
Not sure how I managed it, but I caused a naming conflict in the code that I sent for PR #114.  This resulted in the code completely not working when called via `venn()`.

This PR fixes that issue.  Very sorry to have sent code in a broken state.  I guess the version I tested and the version I committed were not the same.