### PR TITLE
Add a scaleToFit attribute to VennDiagram (fix #76)

### DIFF
--- a/examples/scaled.html
+++ b/examples/scaled.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Scaled venn.js example</title>
+<style>
+body {
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 14px;
+}
+</style>
+</head>
+
+<body>
+    <div id="venn"></div>
+    <p>Adjust scale:</p>
+    <input id="scale_input" type="number" value="50">
+</body>
+
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="../venn.js"></script>
+<script>
+// define sets and set set intersections
+var sets = [ {sets: ['A'], size: 20}, {sets: ['B'], size: 20}, {sets: ['A', 'B'], size: 10}] 
+
+var scale = 50;
+var chart = venn.VennDiagram();
+chart.height(200).width(200);
+
+function draw() {
+    scale = d3.selectAll("#scale_input").nodes()[0].value
+    chart.scaleToFit(scale);
+    d3.select("#venn").datum(sets).call(chart);
+}
+draw();
+
+d3.selectAll("input").on("change", draw);
+
+</script>
+</html>

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -14,6 +14,7 @@ export function VennDiagram() {
         duration = 1000,
         orientation = Math.PI / 2,
         normalize = true,
+        scaleToFit = null,
         wrap = true,
         styled = true,
         fontSize = null,
@@ -69,7 +70,7 @@ export function VennDiagram() {
                                             orientationOrder);
             }
 
-            circles = scaleSolution(solution, width, height, padding);
+            circles = scaleSolution(solution, width, height, padding, scaleToFit);
             textCentres = computeTextCentres(circles, data);
         }
 
@@ -275,6 +276,12 @@ export function VennDiagram() {
     chart.normalize = function(_) {
         if (!arguments.length) return normalize;
         normalize = _;
+        return chart;
+    };
+
+    chart.scaleToFit = function(_) {
+        if (!arguments.length) return scaleToFit;
+        scaleToFit = _;
         return chart;
     };
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -631,8 +631,9 @@ export function normalizeSolution(solution, orientation, orientationOrder) {
 
 /** Scales a solution from venn.venn or venn.greedyLayout such that it fits in
 a rectangle of width/height - with padding around the borders. also
-centers the diagram in the available space at the same time */
-export function scaleSolution(solution, width, height, padding) {
+centers the diagram in the available space at the same time.
+If the scale parameter is not null, this automatic scaling is ignored in favor of this custom one */
+export function scaleSolution(solution, width, height, padding, scaleToFit) {
     var circles = [], setids = [];
     for (var setid in solution) {
         if (solution.hasOwnProperty(setid)) {
@@ -653,11 +654,17 @@ export function scaleSolution(solution, width, height, padding) {
         console.log("not scaling solution: zero size detected");
         return solution;
     }
+    var xScaling, yScaling;
+    if(scaleToFit) {
+        var toScaleDiameter = Math.sqrt(scaleToFit / Math.PI)*2;
+        xScaling = width  / toScaleDiameter;
+        yScaling = height  / toScaleDiameter;
+    } else {
+        xScaling = width  / (xRange.max - xRange.min);
+        yScaling = height / (yRange.max - yRange.min);
+    }
 
-    var xScaling = width  / (xRange.max - xRange.min),
-        yScaling = height / (yRange.max - yRange.min),
-        scaling = Math.min(yScaling, xScaling),
-
+    var scaling = Math.min(yScaling, xScaling),
         // while we're at it, center the diagram too
         xOffset = (width -  (xRange.max - xRange.min) * scaling) / 2,
         yOffset = (height - (yRange.max - yRange.min) * scaling) / 2;


### PR DESCRIPTION
Adds an implementation for https://github.com/benfred/venn.js/issues/76. By using `.scaleToFit(x)`, the Venn Diagram is adjusted so that it would fit an individual circle of area x.